### PR TITLE
Have Jib CLI return correct version (#3150)

### DIFF
--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -15,6 +15,21 @@ application {
   mainClassName = cliMainClass
 }
 
+sourceSets.main.java.srcDirs += ["${buildDir}/generated-src"]
+
+tasks.register('generateSources', Copy) {
+  // to re-run the task whenever the file changes
+  inputs.file 'gradle.properties'
+
+  from fileTree('src/java-templates')
+  into "${buildDir}/generated-src"
+
+  rename('\\.template$', '')
+  expand(['version': "${version}"])
+}
+
+compileJava.source generateSources
+
 dependencies {
   implementation project(':jib-core')
   implementation project(':jib-plugins-common')

--- a/jib-cli/src/java-templates/com/google/cloud/tools/jib/cli/VersionInfo.java.template
+++ b/jib-cli/src/java-templates/com/google/cloud/tools/jib/cli/VersionInfo.java.template
@@ -27,6 +27,6 @@ public class VersionInfo implements CommandLine.IVersionProvider {
   }
 
   public static String getVersionSimple() {
-    return "preview";
+    return "${version}";
   }
 }


### PR DESCRIPTION
#3158 Sets the mod time on TarArchiveEntry to DEFAULT_MODIFICATION_TIME (Epoch second 1) in order to create reproducible Tar images.  Associated unit test creates 2 tars output streams from the same input 2 seconds apart to show the failure if we don't explicitly set the TarArchiveEntry mod time 